### PR TITLE
fix: replaced ODK Aggregate with ODK Central, minor edits

### DIFF
--- a/learning-content/beginners-guides/open-source-for-MERL-workflows-MERLlifecycle.md
+++ b/learning-content/beginners-guides/open-source-for-MERL-workflows-MERLlifecycle.md
@@ -53,18 +53,19 @@ MERL Technology Workflow | Tasks and Functionalities | MERL Output | Examples Op
 Data Analysis and Visualization | <ul><li>Create visual representations of theories</li><li>Create visual representations of frameworks</li><li>Track KPIs</li></ul> | Theory of change | Theorymaker | http://theorymaker.info/ | https://github.com/optimus-sma/theorymaker
 "  | "  | Evaluation matrix | Kashana | http://kashana.org/ | https://github.com/aptivate/kashana | 
 "  | "  | Key performance indicators (measurement) framework | Kashana | http://kashana.org/ | --
-Data Analysis and Visualization | <ul><li>Create visual representations of MERL activities</li><li>Project management</li></ul> | MERL Gannt/Project Timeline | OpenProject | https://www.openproject.org/ | https://github.com/opf/openproject
+Data Analysis and Visualization | <ul><li>Create visual representations of MERL activities</li><li>Project management</li></ul> | MERL Gantt/Project Timeline | OpenProject | https://www.openproject.org/ | https://github.com/opf/openproject
 "  | "  | Roles and responsibilities for MERL org chart | diagrams.net | https://www.diagrams.net/ | https://github.com/jgraph/drawio
 Data Analysis and Visualization | Create [visual] representations of theories and frameworks | Theory of change | Theorymaker | http://theorymaker.info/ | https://github.com/optimus-sma/theorymaker
 "  | Evaluation matrix | Kashana | http://kashana.org/ | https://github.com/aptivate/kashana 
-Data Collection and Management | <ul><li>Create surveys</li><li>Create and store quantitative data</li><li>Create and store qualitative data</li></ul> | Survey data | Kobo Toolbox | https://www.kobotoolbox.org/ | https://github.com/optimus-sma/theorymaker
+Data Collection and Management | <ul><li>Create surveys</li><li>Create and store quantitative data</li><li>Create and store qualitative data</li></ul> | Survey data | Kobo Toolbox | https://www.kobotoolbox.org/
+"  | Loads forms and collect data offline  | Survey data| ODK Collect| https://docs.getodk.org/collect-intro/
+"  | Design and manage forms and its submissions  | Survey data | ODK Central | https://docs.getodk.org/getting-started/#get-a-central-server
 "  | "  | Interview recordings/transcriptions | oTranscribe | https://otranscribe.com/ | https://github.com/oTranscribe/oTranscribe
 "  | "  | Database management | PostgreSQL | https://www.postgresql.org/ | https://github.com/postgres/postgres/
 Data Analysis and Visualization, Reporting | <ul><li>Perform statistical analyses</li><li>Perform text analysis</li><li>Perform content analysis</li><li>Generate data visualizations</li></ul> | Statistical analysis (descriptive and inferential) | https://www.r-project.org/ | https://github.com/r-lib
 "  | "  | Text and content analysis | Coding Analysis Toolkit | https://cat.texifter.com/ | -- 
 "  | "  | Geospatial analysis | QGIS | https://qgis.org/en/site/ | https://github.com/qgis
 "  | "  | Documents - Word processing | LibreOffice | https://www.libreoffice.org/ | https://github.com/LibreOffice
-"  | "  | Spreadsheet tracking/analysis | ODK Aggregate | https://docs.getodk.org/aggregate-intro/ https://github.com/getodk/aggregate/releases/tag/v2.0.5
 "  | "  | Dashboard creation | Rstudio Shiny | https://rstudio.github.io/shinydashboard/ | https://github.com/rstudio/shinydashboard
 
 One goal of the [MERL Center on GitHub](https://merltech.github.io/MERL-Center-public/) is to help MERL practitioners identify open source tools for each stage of the MERL lifecycle, MERL technology workflow, functionality and output to increase adoption. By identifying examples of open source tools for each, we may encourage greater adoption of open source in MERL work.


### PR DESCRIPTION
- Replaced ODK Aggregate (now deprecated) with ODK Central as main data collection server: https://docs.getodk.org/aggregate-intro/
- Moved ODK Central under the `Create survey` section
- Added ODK Collect as a tool under the `Create survey` section