### PR TITLE
Fix server not showing changes to collections on localhost

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Home of GitHub Satellite",
   "main": "index.js",
   "scripts": {
-    "start": "bundle exec jekyll serve --incremental --livereload",
+    "start": "bundle exec jekyll serve --livereload",
     "test": "npx stylelint 'assets/**/*.scss' --config .github/linters/.stylelintrc --ignore-path .github/linters/.stylelintignore"
   },
   "repository": {


### PR DESCRIPTION
Fixes #122 

### What changes and why
- removed the `--incremental` flag from the start command because incremental regeneration was causing changes to not be reflected because the `post-preview.html` file was not being re-built on changes to collection markdown files 
- Incremental regeneration can make building site faster after changes by only re-building the files that have changed but I did not notice any difference in the time it takes to see changes reflected on localhost after removing it


