### PR TITLE
Setup Docker for Local Development Environment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git/
+.github/
+.gitignore

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,8 @@
 .git/
 .github/
 .gitignore
+node_modules/
+package.json
+package-lock.json
+.jekyll-cache
+_site

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,0 @@
-.git/
-.github/
-.gitignore
-node_modules/
-package.json
-package-lock.json
-.jekyll-cache
-_site

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+# https://hub.docker.com/_/ruby
+FROM ruby:3.0
+
+# throw errors if Gemfile has been modified since Gemfile.lock
+RUN bundle config --global frozen 1
+
+WORKDIR /usr/src/app
+
+COPY Gemfile Gemfile.lock ./
+RUN bundle install
+
+COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,9 @@ RUN bundle config --global frozen 1
 
 WORKDIR /usr/src/app
 
+# copy gems first to cache bundle install
 COPY Gemfile Gemfile.lock ./
 RUN bundle install
 
+# copy whole repo into the image
 COPY . .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,16 @@
 version: '3'
 services:
   jekyll:
+    container_name: jekyll-server
     build:
       context: .
       dockerfile: Dockerfile
+    image: merl-center:v1
     # host flag allows Jekyll server to be accessed from outside the container
     command: bundle exec jekyll serve --livereload --host=0.0.0.0
     # volume allows changes to be seen on localhost immediately instead of having to delete and rebuild image
     volumes:
       - .:/usr/src/app
-    # 35729 is the port for livereload
     ports:
       - 4000:4000
-      - 35729:35729
+      - 35729:35729 # port for livereload

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,9 +4,12 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    # host flag allows Jekyll server to be accessed from outside the container
     command: bundle exec jekyll serve --livereload --host=0.0.0.0
+    # volume allows changes to be seen on localhost immediately instead of having to delete and rebuild image
     volumes:
       - .:/usr/src/app
+    # 35729 is the port for livereload
     ports:
       - 4000:4000
       - 35729:35729

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3'
+services:
+  jekyll:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    command: bundle exec jekyll serve --livereload --host=0.0.0.0
+    volumes:
+      - .:/usr/src/app
+    ports:
+      - 4000:4000
+      - 35729:35729


### PR DESCRIPTION
Fixes #124 

### What changes and why?
- setup a `docker-compose.yml` and a `Dockerfile` to allow devs who have docker installed on their machine to start app on `localhost:4000` with just the command `docker compose up`
- Used `ruby:3.0` as the base image for the `Dockerfile` because it comes with Ruby pre-installed and is still relatively small which allows for faster build times